### PR TITLE
chore: normalize head assets and nav script

### DIFF
--- a/SHEMA copy/about/index.html
+++ b/SHEMA copy/about/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/about.html" />
-    <meta property="og:image" content="/images/previews/about.png" />
+    <meta property="og:image" content="./images/previews/about.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,13 @@
       name="twitter:description"
       content="Learn about SHEMA's mission to restore Scripture's Jewish roots through AI-powered commentary and Messianic scholarship."
     />
-    <meta name="twitter:image" content="/images/previews/about.png" />
+    <meta name="twitter:image" content="./images/previews/about.png" />
 
-    <!-- Favicons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color -->
     <meta name="theme-color" content="#141414" />
@@ -50,10 +51,9 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/_pages/about.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     <!--#include file="../partials/header.html" -->
@@ -61,7 +61,7 @@
     <main><div>This id the main body</div></main>
     <!--#include file="../partials/footer.html" -->
 
-    <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/blog/index.html
+++ b/SHEMA copy/blog/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/blog.html" />
-    <meta property="og:image" content="/images/previews/blog.png" />
+    <meta property="og:image" content="./images/previews/blog.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,13 @@
       name="twitter:description"
       content="Read SHEMA's blog for insights on Scripture's Jewish roots, cultural context, and AI-powered Bible study tips."
     />
-    <meta name="twitter:image" content="/images/previews/blog.png" />
+    <meta name="twitter:image" content="./images/previews/blog.png" />
 
-    <!-- Favicons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color -->
     <meta name="theme-color" content="#141414" />
@@ -50,10 +51,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/blog.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/blog.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
 
   <body>
@@ -91,7 +92,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -109,7 +110,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -133,7 +134,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -151,7 +152,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -176,7 +177,7 @@
     </main>
     <!--#include file="../partials/footer.html" -->
 
-    <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/contact-us/index.html
+++ b/SHEMA copy/contact-us/index.html
@@ -18,15 +18,18 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
-    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="css/nav.css" />
-    <link rel="stylesheet" href="css/styles.css" />
-    <link rel="stylesheet" href="css/footer.css" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
     <link
       href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap"
       rel="stylesheet"
@@ -38,25 +41,6 @@
     <main><div>This id the main body</div></main>
     <!--#include file="../partials/footer.html" -->
 
-    <script>
-      const toggle = document.querySelector(".nav-toggle");
-      const closeBtn = document.querySelector(".mobile-close");
-      const mobileMenu = document.getElementById("mobileMenu");
-
-      toggle.addEventListener("click", () => {
-        mobileMenu.classList.add("active");
-      });
-
-      closeBtn.addEventListener("click", () => {
-        mobileMenu.classList.remove("active");
-      });
-
-      // ✅ Auto-close on resize
-      window.addEventListener("resize", () => {
-        if (window.innerWidth > 690) {
-          mobileMenu.classList.remove("active");
-        }
-      });
-    </script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/explore/index.html
+++ b/SHEMA copy/explore/index.html
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,13 +43,14 @@
     />
     <meta
       name="twitter:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
 
-    <!-- Icons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color (optional) -->
     <meta name="theme-color" content="#141414" />
@@ -63,10 +64,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/_pages/explore.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/explore.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     <!--#include file="../partials/header.html" -->
@@ -106,13 +107,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -152,13 +153,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -198,13 +199,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -262,7 +263,7 @@
                 <a href="/why-jewish-context.html" class="faq-link">
                   why jewish Context
                   <img
-                    src="/images/global/icons/go-icon.svg"
+                    src="./images/global/icons/go-icon.svg"
                     alt="nort-east arrow icon"
                   />
                 </a>
@@ -296,7 +297,7 @@
     </main>
     <!--#include file="../partials/footer.html" -->
 
-    <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/faq/index.html
+++ b/SHEMA copy/faq/index.html
@@ -14,7 +14,7 @@
     <meta property="og:description" content="Find answers to frequently asked questions about SHEMA, our mission, features, and how to get involved." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/faq.html" />
-    <meta property="og:image" content="/images/previews/faq.png" />
+    <meta property="og:image" content="./images/previews/faq.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -22,12 +22,13 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FAQ | SHEMA" />
     <meta name="twitter:description" content="Find answers to frequently asked questions about SHEMA, our mission, features, and how to get involved." />
-    <meta name="twitter:image" content="/images/previews/faq.png" />
+    <meta name="twitter:image" content="./images/previews/faq.png" />
 
-    <!-- Favicons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color -->
     <meta name="theme-color" content="#141414" />
@@ -38,9 +39,10 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap" rel="stylesheet" />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/faq.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     <!--#include file="../partials/header.html" -->
@@ -179,7 +181,7 @@
       </section>
     <!--#include file="../partials/footer.html" -->
 
-   <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/privacy/index.html
+++ b/SHEMA copy/privacy/index.html
@@ -18,15 +18,18 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
-    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="css/nav.css" />
-    <link rel="stylesheet" href="css/styles.css" />
-    <link rel="stylesheet" href="css/footer.css" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
     <link
       href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap"
       rel="stylesheet"
@@ -38,25 +41,6 @@
     <main><div>This id the main body</div></main>
     <!--#include file="../partials/footer.html" -->
 
-    <script>
-      const toggle = document.querySelector(".nav-toggle");
-      const closeBtn = document.querySelector(".mobile-close");
-      const mobileMenu = document.getElementById("mobileMenu");
-
-      toggle.addEventListener("click", () => {
-        mobileMenu.classList.add("active");
-      });
-
-      closeBtn.addEventListener("click", () => {
-        mobileMenu.classList.remove("active");
-      });
-
-      // ✅ Auto-close on resize
-      window.addEventListener("resize", () => {
-        if (window.innerWidth > 690) {
-          mobileMenu.classList.remove("active");
-        }
-      });
-    </script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/support/index.html
+++ b/SHEMA copy/support/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/support.html" />
-    <meta property="og:image" content="/images/previews/support.png" />
+    <meta property="og:image" content="./images/previews/support.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,13 @@
       name="twitter:description"
       content="Support SHEMA's mission to make authentic Jewish context accessible to every believer through AI-powered Bible study tools."
     />
-    <meta name="twitter:image" content="/images/previews/support.png" />
+    <meta name="twitter:image" content="./images/previews/support.png" />
 
-    <!-- Favicons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color -->
     <meta name="theme-color" content="#141414" />
@@ -50,9 +51,9 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     <!--#include file="../partials/header.html" -->
@@ -60,7 +61,7 @@
     <main><div>This id the main body</div></main>
     <!--#include file="../partials/footer.html" -->
 
-    <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/thank-you/index.html
+++ b/SHEMA copy/thank-you/index.html
@@ -18,15 +18,18 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
-    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="css/nav.css" />
-    <link rel="stylesheet" href="css/styles.css" />
-    <link rel="stylesheet" href="css/footer.css" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
     <link
       href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap"
       rel="stylesheet"
@@ -38,25 +41,6 @@
     <main><div>This id the main body</div></main>
     <!--#include file="../partials/footer.html" -->
 
-    <script>
-      const toggle = document.querySelector(".nav-toggle");
-      const closeBtn = document.querySelector(".mobile-close");
-      const mobileMenu = document.getElementById("mobileMenu");
-
-      toggle.addEventListener("click", () => {
-        mobileMenu.classList.add("active");
-      });
-
-      closeBtn.addEventListener("click", () => {
-        mobileMenu.classList.remove("active");
-      });
-
-      // ✅ Auto-close on resize
-      window.addEventListener("resize", () => {
-        if (window.innerWidth > 690) {
-          mobileMenu.classList.remove("active");
-        }
-      });
-    </script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/why-jewish-context/index.html
+++ b/SHEMA copy/why-jewish-context/index.html
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,13 +43,14 @@
     />
     <meta
       name="twitter:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
 
-    <!-- Icons -->
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="./shin-favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
+    <link rel="manifest" href="./manifest.webmanifest" />
 
     <!-- Theme color (optional) -->
     <meta name="theme-color" content="#141414" />
@@ -63,10 +64,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/_pages/why.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/why.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     <!--#include file="../partials/header.html" -->
@@ -174,7 +175,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -192,7 +193,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -337,7 +338,7 @@
     </main>
     <!--#include file="../partials/footer.html" -->
 
-    <script src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- use relative asset paths and unified head icon set
- standardize CSS order and add missing manifest link
- load nav.js with defer across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898dd84d408832e854e0fa3b470c008