### PR TITLE
Normalize asset paths and add missing theme colors

### DIFF
--- a/SHEMA copy/blog/index.html
+++ b/SHEMA copy/blog/index.html
@@ -92,7 +92,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-1.png"
+                src="/images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -110,7 +110,7 @@
             </div>
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-2.png"
+                src="/images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -134,7 +134,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-1.png"
+                src="/images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -152,7 +152,7 @@
             </div>
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-2.png"
+                src="/images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">

--- a/SHEMA copy/contact-us/index.html
+++ b/SHEMA copy/contact-us/index.html
@@ -28,6 +28,8 @@
     <!-- TODO: supply /icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
+    <meta name="theme-color" content="#141414" />
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/SHEMA copy/explore/index.html
+++ b/SHEMA copy/explore/index.html
@@ -107,13 +107,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -153,13 +153,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -199,13 +199,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="./images/pages/explore/place-holder.png" alt="" />
+            <img src="/images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -263,7 +263,7 @@
                 <a href="/why-jewish-context.html" class="faq-link">
                   why jewish Context
                   <img
-                    src="./images/global/icons/go-icon.svg"
+                    src="/images/global/icons/go-icon.svg"
                     alt="nort-east arrow icon"
                   />
                 </a>

--- a/SHEMA copy/privacy/index.html
+++ b/SHEMA copy/privacy/index.html
@@ -28,6 +28,8 @@
     <!-- TODO: supply /icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
+    <meta name="theme-color" content="#141414" />
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/SHEMA copy/thank-you/index.html
+++ b/SHEMA copy/thank-you/index.html
@@ -28,6 +28,8 @@
     <!-- TODO: supply /icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
+    <meta name="theme-color" content="#141414" />
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/SHEMA copy/why-jewish-context/index.html
+++ b/SHEMA copy/why-jewish-context/index.html
@@ -175,7 +175,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-1.png"
+                src="/images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -193,7 +193,7 @@
             </div>
             <div class="card">
               <img
-                src="./images/pages/why-jewish/ol-img-2.png"
+                src="/images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">


### PR DESCRIPTION
## Summary
- convert relative image asset paths to root-relative
- add missing theme-color meta tags

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689908660d28832ebf3edeb5c7bde4a2