### PR TITLE
chore: normalize HTML asset references

### DIFF
--- a/SHEMA copy/about/index.html
+++ b/SHEMA copy/about/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/about.html" />
-    <meta property="og:image" content="/images/previews/about.png" />
+    <meta property="og:image" content="./images/previews/about.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,12 @@
       name="twitter:description"
       content="Learn about SHEMA's mission to restore Scripture's Jewish roots through AI-powered commentary and Messianic scholarship."
     />
-    <meta name="twitter:image" content="/images/previews/about.png" />
+    <meta name="twitter:image" content="./images/previews/about.png" />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color -->
@@ -51,9 +51,9 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -61,7 +61,7 @@
     <main><div>This id the main body</div></main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/blog/index.html
+++ b/SHEMA copy/blog/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/blog.html" />
-    <meta property="og:image" content="/images/previews/blog.png" />
+    <meta property="og:image" content="./images/previews/blog.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,12 @@
       name="twitter:description"
       content="Read SHEMA's blog for insights on Scripture's Jewish roots, cultural context, and AI-powered Bible study tips."
     />
-    <meta name="twitter:image" content="/images/previews/blog.png" />
+    <meta name="twitter:image" content="./images/previews/blog.png" />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color -->
@@ -51,10 +51,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/blog.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/blog.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
 
   <body>
@@ -92,7 +92,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -110,7 +110,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -134,7 +134,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -152,7 +152,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -177,7 +177,7 @@
     </main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/contact-us/index.html
+++ b/SHEMA copy/contact-us/index.html
@@ -18,14 +18,14 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <meta name="theme-color" content="#141414" />
@@ -36,9 +36,9 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap" rel="stylesheet" />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -46,6 +46,6 @@
     <main><div>This id the main body</div></main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/explore/index.html
+++ b/SHEMA copy/explore/index.html
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,13 +43,13 @@
     />
     <meta
       name="twitter:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color (optional) -->
@@ -64,10 +64,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/_pages/explore.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/explore.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -107,13 +107,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -153,13 +153,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -199,13 +199,13 @@
             </p>
           </div>
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
         </div>
 
         <div class="container">
           <div class="gif-container">
-            <img src="/images/pages/explore/place-holder.png" alt="" />
+            <img src="./images/pages/explore/place-holder.png" alt="" />
           </div>
           <div class="text" class="h3-card-subtitle">
             <h2>How Did Jesus Really Teach?</h2>
@@ -263,7 +263,7 @@
                 <a href="/why-jewish-context.html" class="faq-link">
                   why jewish Context
                   <img
-                    src="/images/global/icons/go-icon.svg"
+                    src="./images/global/icons/go-icon.svg"
                     alt="nort-east arrow icon"
                   />
                 </a>
@@ -297,7 +297,7 @@
     </main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/faq/index.html
+++ b/SHEMA copy/faq/index.html
@@ -14,7 +14,7 @@
     <meta property="og:description" content="Find answers to frequently asked questions about SHEMA, our mission, features, and how to get involved." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/faq.html" />
-    <meta property="og:image" content="/images/previews/faq.png" />
+    <meta property="og:image" content="./images/previews/faq.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -22,12 +22,12 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FAQ | SHEMA" />
     <meta name="twitter:description" content="Find answers to frequently asked questions about SHEMA, our mission, features, and how to get involved." />
-    <meta name="twitter:image" content="/images/previews/faq.png" />
+    <meta name="twitter:image" content="./images/previews/faq.png" />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color -->
@@ -39,10 +39,10 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap" rel="stylesheet" />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/_pages/faq.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/faq.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -181,7 +181,7 @@
       </section>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/index.html
+++ b/SHEMA copy/index.html
@@ -93,15 +93,6 @@
             loading="lazy"
             decoding="async"
           />
-          <img
-            src="/images/pages/home/carousel-screens.png"
-            alt=""
-            aria-hidden="true"
-            width="1920"
-            height="1080"
-            loading="lazy"
-            decoding="async"
-          />
         </div>
       </section>
 
@@ -257,16 +248,8 @@
             alt="logo-placeholder"
           />
           <img
-            src="/images/pages/home/placeholder-logo.svg"
-            alt="logo-placeholder"
-          />
-          <img
             src="/images/pages/home/rilo-logo.svg"
             alt="Rooted In Love Outreach logo"
-          />
-          <img
-            src="/images/pages/home/placeholder-logo.svg"
-            alt="logo-placeholder"
           />
           <img
             src="/images/pages/home/placeholder-logo.svg"
@@ -389,6 +372,6 @@
 
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/privacy/index.html
+++ b/SHEMA copy/privacy/index.html
@@ -18,14 +18,14 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <meta name="theme-color" content="#141414" />
@@ -36,9 +36,9 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap" rel="stylesheet" />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -46,6 +46,6 @@
     <main><div>This id the main body</div></main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/support/index.html
+++ b/SHEMA copy/support/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/support.html" />
-    <meta property="og:image" content="/images/previews/support.png" />
+    <meta property="og:image" content="./images/previews/support.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
@@ -31,12 +31,12 @@
       name="twitter:description"
       content="Support SHEMA's mission to make authentic Jewish context accessible to every believer through AI-powered Bible study tools."
     />
-    <meta name="twitter:image" content="/images/previews/support.png" />
+    <meta name="twitter:image" content="./images/previews/support.png" />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color -->
@@ -51,9 +51,9 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -61,7 +61,7 @@
     <main><div>This id the main body</div></main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 

--- a/SHEMA copy/thank-you/index.html
+++ b/SHEMA copy/thank-you/index.html
@@ -18,14 +18,14 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yourdomain.com/context.html" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <meta name="theme-color" content="#141414" />
@@ -36,9 +36,9 @@
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic&display=swap" rel="stylesheet" />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -46,6 +46,6 @@
     <main><div>This id the main body</div></main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>

--- a/SHEMA copy/why-jewish-context/index.html
+++ b/SHEMA copy/why-jewish-context/index.html
@@ -29,7 +29,7 @@
     />
     <meta
       property="og:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -43,13 +43,13 @@
     />
     <meta
       name="twitter:image"
-      content="/images/previews/why-jewish-context.png"
+      content="./images/previews/why-jewish-context.png"
     />
 
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" href="/shin-favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <!-- TODO: supply /icons/apple-touch-icon.png -->
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- TODO: supply ./icons/apple-touch-icon.png -->
     <link rel="manifest" href="/manifest.webmanifest" />
 
     <!-- Theme color (optional) -->
@@ -64,10 +64,10 @@
     />
 
     <!-- CSS (order: globals, then components) -->
-    <link rel="stylesheet" href="/css/styles.css" />
-    <link rel="stylesheet" href="/css/components/nav.css" />
-    <link rel="stylesheet" href="/css/_pages/why.css" />
-    <link rel="stylesheet" href="/css/components/footer.css" />
+    <link rel="stylesheet" href="./css/styles.css" />
+    <link rel="stylesheet" href="./css/components/nav.css" />
+    <link rel="stylesheet" href="./css/_pages/why.css" />
+    <link rel="stylesheet" href="./css/components/footer.css" />
   </head>
   <body>
     {% include "header.html" %}
@@ -175,7 +175,7 @@
           <div class="cards-wrapper">
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-1.png"
+                src="./images/pages/why-jewish/ol-img-1.png"
                 alt="Group reading"
               />
               <div class="text-wrapper">
@@ -193,7 +193,7 @@
             </div>
             <div class="card">
               <img
-                src="/images/pages/why-jewish/ol-img-2.png"
+                src="./images/pages/why-jewish/ol-img-2.png"
                 alt="Man teaching"
               />
               <div class="text-wrapper">
@@ -338,7 +338,7 @@
     </main>
     {% include "footer.html" %}
 
-    <script defer src="/js/nav.js"></script>
+    <script defer src="./js/nav.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- dedupe duplicate carousel and partner images on home page
- normalize nav.js script tag and CSS asset links
- convert subpage asset paths to relative references

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689911f38770832e9cc1f2488369f478