### PR TITLE
chore: add project configs and README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,2 @@
 node_modules/
 _site/
-
-# macOS
-.DS_Store

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# SHEMA-Web-Copy
-Product Marketing Website
+# SHEMA Web
+
+## Requirements
+- Node 18+
+
+## Install
+```sh
+npm install
+```
+
+## Develop
+```sh
+npm run start
+```
+Serves Eleventy and watches files.
+
+## Build
+```sh
+npm run build
+```
+Outputs to `_site/`.
+
+## Folder notes
+- Source lives in the repo (includes `_includes/` and `SHEMA copy/` pages).
+- Built site is `_site/` (ignored by git).
+
+## Conventions
+- Use Prettier (`.prettierrc.json`) and EditorConfig
+- HTML templating via Nunjucks `{% include %}` with `_includes/header.html` and `_includes/footer.html`
+
+## Next tasks
+- [ ] Provide `./icons/apple-touch-icon.png` (180×180)
+- [ ] Replace placeholder canonical/og:url with real domain
+- [ ] Cloudflare Pages setup (build: `npm run build`, output: `_site/`)
+
+## License
+License/attribution placeholder.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "scripts": {
     "dev": "ELEVENTY_ENV=dev npx @11ty/eleventy --serve",
-    "build": "npx @11ty/eleventy",
-    "serve": "npx @11ty/eleventy --serve"
+    "build": "eleventy",
+    "serve": "npx @11ty/eleventy --serve",
+    "start": "eleventy --serve"
   }
 }


### PR DESCRIPTION
## Summary
- add EditorConfig, Prettier config, and ignore files
- streamline npm scripts and expand project README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689944744f58832ea6d5c1639dca8e3c