### PR TITLE
chore: tidy config and docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,10 +3,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 _site/
-
-# macOS
+# macOS Finder files
 .DS_Store
+# IDEs
+.idea/
+.vscode/
+# env
+.env

--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
 # SHEMA Web
 
-## Requirements
-- Node 18+
+Static site built with [Eleventy (11ty)] using build-time includes.
 
-## Install
-```sh
+## Prerequisites
+
+* Node.js 18+
+
+## Setup
+
+```bash
 npm install
 ```
 
-## Develop
-```sh
-npm run start
-```
-Serves Eleventy and watches files.
+## Local development
 
-## Build
-```sh
+```bash
+npm run dev
+```
+
+This serves the site and watches for changes. Output is written to `_site/`.
+
+## Production build
+
+```bash
 npm run build
 ```
-Outputs to `_site/`.
 
-## Folder notes
-- Source lives in the repo (includes `_includes/` and `SHEMA copy/` pages).
-- Built site is `_site/` (ignored by git).
+## Structure
 
-## Conventions
-- Use Prettier (`.prettierrc.json`) and EditorConfig
-- HTML templating via Nunjucks `{% include %}` with `_includes/header.html` and `_includes/footer.html`
+* `_includes/` — shared templates/partials (header, footer, head, layouts)
+* `SHEMA copy/` — page content, assets, css/js
+* `_site/` — generated output (ignored by git)
 
-## Next tasks
-- [ ] Provide `./icons/apple-touch-icon.png` (180×180)
-- [ ] Replace placeholder canonical/og:url with real domain
-- [ ] Cloudflare Pages setup (build: `npm run build`, output: `_site/`)
+## Notes
 
-## License
-License/attribution placeholder.
+* `nav.js` is loaded once from the shared footer include. Do not add page-level `<script src="./js/nav.js">` tags.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@11ty/eleventy": "^3.0.0"
   },
   "scripts": {
-    "dev": "ELEVENTY_ENV=dev npx @11ty/eleventy --serve",
+    "dev": "eleventy --serve",
     "build": "eleventy",
     "serve": "npx @11ty/eleventy --serve",
     "start": "eleventy --serve"


### PR DESCRIPTION
## Summary
- streamline .gitignore to cover node modules, build output, IDE files, and env vars
- simplify editorconfig to enforce UTF-8, LF, 2-space indentation, and trailing newline trimming
- align npm scripts with Eleventy defaults and rewrite README with setup and structure details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68995fba7878832e9af6779ec4ab2a7d