### PR TITLE
Add QA link and HTML validation checks with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run check:all

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "shema-web",
   "private": true,
   "devDependencies": {
-    "@11ty/eleventy": "^3.0.0"
+    "@11ty/eleventy": "^3.0.0",
+    "@html-validate/cli": "^8.0.0",
+    "linkinator": "^6.0.0"
   },
   "scripts": {
     "dev": "eleventy --serve",
     "build": "eleventy",
+    "check:links": "npm run build && npx linkinator _site --silent --recurse",
+    "check:html": "npm run build && npx html-validate \"_site/**/*.html\"",
+    "check:all": "npm run check:links && npm run check:html",
     "serve": "npx @11ty/eleventy --serve",
     "start": "eleventy --serve"
   }


### PR DESCRIPTION
## Summary
- add linkinator and html-validate CLI as dev dependencies
- add link and HTML validation scripts
- run link and HTML validation in GitHub Actions CI

## Testing
- `npm run check:all` *(fails: 403 Forbidden - GET https://registry.npmjs.org/linkinator)*

------
https://chatgpt.com/codex/tasks/task_e_689980726984832eae0634f2e7a0d493