### PR TITLE
Remove per-page canonical and ogUrl

### DIFF
--- a/site/about/index.html
+++ b/site/about/index.html
@@ -2,10 +2,8 @@
 layout: layouts/base.njk
 title: "About | SHEMA — AI-Powered Jewish Context Bible App"
 description: "Learn about SHEMA's mission to restore Scripture's Jewish roots through AI-powered commentary and Messianic scholarship."
-canonical: "https://yourdomain.com/about.html"
 ogTitle: "About | SHEMA"
 ogDescription: "Learn about SHEMA's mission to restore Scripture's Jewish roots through AI-powered commentary and Messianic scholarship."
-ogUrl: "https://yourdomain.com/about.html"
 ogImage: "./images/previews/about.png"
 twitterCard: "summary_large_image"
 twitterTitle: "About | SHEMA"

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -2,10 +2,8 @@
 layout: layouts/base.njk
 title: "Blog | SHEMA — AI-Powered Jewish Context Bible App"
 description: "Read SHEMA's blog for insights on Scripture's Jewish roots, cultural context, and AI-powered Bible study tips."
-canonical: "https://yourdomain.com/blog.html"
 ogTitle: "Blog | SHEMA"
 ogDescription: "Read SHEMA's blog for insights on Scripture's Jewish roots, cultural context, and AI-powered Bible study tips."
-ogUrl: "https://yourdomain.com/blog.html"
 ogImage: "./images/previews/blog.png"
 twitterCard: "summary_large_image"
 twitterTitle: "Blog | SHEMA"

--- a/site/contact-us/index.html
+++ b/site/contact-us/index.html
@@ -5,5 +5,4 @@ description: "Discover why understanding the Jewish context of the Bible matters
 ogTitle: "Why Jewish Context | SHEMA"
 ogDescription: "Discover why understanding the Jewish context of the Bible matters. Learn how SHEMA helps restore the original voice of Scripture."
 ogImage: "./images/previews/why-jewish-context.png"
-ogUrl: "https://yourdomain.com/context.html"
 ---

--- a/site/index.html
+++ b/site/index.html
@@ -2,10 +2,8 @@
 layout: layouts/base.njk
 title: "SHEMA — AI-Powered Jewish Context Bible App"
 description: "Discover the Bible’s Jewish roots with AI-assisted commentary grounded in Messianic Jewish sources."
-canonical: "https://yourdomain.com/"
 ogTitle: "SHEMA — AI-Powered Jewish Context Bible App"
 ogDescription: "Discover the Bible’s Jewish roots with AI-assisted commentary grounded in Messianic Jewish sources."
-ogUrl: "https://yourdomain.com/"
 twitterCard: "summary_large_image"
 twitterTitle: "SHEMA — AI-Powered Jewish Context Bible App"
 twitterDescription: "Discover the Bible’s Jewish roots with AI-assisted commentary grounded in Messianic Jewish sources."

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -5,5 +5,4 @@ description: "Discover why understanding the Jewish context of the Bible matters
 ogTitle: "Why Jewish Context | SHEMA"
 ogDescription: "Discover why understanding the Jewish context of the Bible matters. Learn how SHEMA helps restore the original voice of Scripture."
 ogImage: "./images/previews/why-jewish-context.png"
-ogUrl: "https://yourdomain.com/context.html"
 ---

--- a/site/support/index.html
+++ b/site/support/index.html
@@ -2,10 +2,8 @@
 layout: layouts/base.njk
 title: "Support | SHEMA — AI-Powered Jewish Context Bible App"
 description: "Support SHEMA's mission to make authentic Jewish context accessible to every believer through AI-powered Bible study tools."
-canonical: "https://yourdomain.com/support.html"
 ogTitle: "Support | SHEMA"
 ogDescription: "Support SHEMA's mission to make authentic Jewish context accessible to every believer through AI-powered Bible study tools."
-ogUrl: "https://yourdomain.com/support.html"
 ogImage: "./images/previews/support.png"
 twitterCard: "summary_large_image"
 twitterTitle: "Support | SHEMA"

--- a/site/thank-you/index.html
+++ b/site/thank-you/index.html
@@ -5,5 +5,4 @@ description: "Discover why understanding the Jewish context of the Bible matters
 ogTitle: "Why Jewish Context | SHEMA"
 ogDescription: "Discover why understanding the Jewish context of the Bible matters. Learn how SHEMA helps restore the original voice of Scripture."
 ogImage: "./images/previews/why-jewish-context.png"
-ogUrl: "https://yourdomain.com/context.html"
 ---


### PR DESCRIPTION
## Summary
- remove canonical and ogUrl fields from front matter across site pages now handled centrally in head.njk【F:site/index.html†L1-L10】【F:site/about/index.html†L1-L12】【F:site/blog/index.html†L1-L14】【F:site/support/index.html†L1-L12】【F:site/contact-us/index.html†L1-L8】【F:site/privacy/index.html†L1-L8】【F:site/thank-you/index.html†L1-L8】

## Testing
- `npm test` (fails: Missing script)【79a7a8†L1-L7】
- `npm run build`【12055a†L1-L17】

------
https://chatgpt.com/codex/tasks/task_e_689a87435b48832eaafd282ee1f4bf1a