### PR TITLE
chore: normalize husky hooks

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -14,7 +14,7 @@ if [ -z "$husky_skip_init" ]; then
     . ~/.huskyrc
   fi
   export readonly husky_skip_init=1
-  sh -e "$0" "$@"
+  sh -e -- "$0" "$@"
   exitCode=$?
   unset husky_skip_init
   exit $exitCode

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 
-exit 0
+if [ -f commitlint.config.js ] || [ -f commitlint.config.cjs ] || [ -f commitlint.config.mjs ] || \
+   [ -f .commitlintrc ] || [ -f .commitlintrc.json ] || [ -f .commitlintrc.js ] || \
+   [ -f .commitlintrc.cjs ] || [ -f .commitlintrc.mjs ]; then
+  npx --yes commitlint --edit "$1"
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- normalize husky re-exec to support git `--file -`
- conditionally run commitlint in commit-msg hook

## Testing
- `git config --get core.hooksPath`
- `sh -x .husky/pre-commit`
- `sh -x .husky/commit-msg -`
- `sh -x .husky/post-commit`
- `printf "ok\n" | HUSKY_DEBUG=1 git commit --allow-empty -F -`


------
https://chatgpt.com/codex/tasks/task_e_689fb7ff67ec832ea6f90d2fb241bd92